### PR TITLE
Ghost overtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Server requirements:
 
 Some optional features also require:
   - Up-to-date <a target="_blank" href="https://github.com/alliedmodders/sourcemod/tree/master/gamedata">Neotokyo gamedata</a>
-  - <a target="_blank" href="https://github.com/softashell/nt-sourcemod-plugins">Ghostcap event plugin</a> 1.5.4 or later
+  - <a target="_blank" href="https://github.com/softashell/nt-sourcemod-plugins">Ghostcap event plugin</a> 1.9.0 or later
 
 Plugin cvars:
 ```
@@ -64,3 +64,21 @@ sm_competitive_display_remaining_players_target  		- Who to center display remai
 sm_competitive_keyvalues_test							- Store match data into KeyValues file. Debug cvar. Default: 1
 sm_competitive_force_camera				    			- Should fade to black be forced on death when live. Can be useful to disable on pugs etc. Default: 1
 ```
+
+The overtime is controlled by four new cvars
+
+    * sm_competitive_ghost_overtime (Default: 45)
+        * Controls in seconds the maximum amount of overtime that can be added to the base clock.
+    * sm_competitive_ghost_overtime_grace (Default: 15)
+        * Controls at how many seconds on the clock the overtime kicks in.
+    * sm_competitive_ghost_overtime_grace_reset (Default: 1)
+        * Controls whether the grace time should be reset when picking up the ghost. The grace time will never be reset fully, but instead set to what the timer would have been at if the ghost had been held from when the timer showed sm_competitive_ghost_overtime_grace. I.e. a round can never be extended by more than what sm_competitive_ghost_overtime is set to.
+    * sm_competitive_ghost_overtime_decay_exp (Default: 0)
+        * There are two modes for the timer decay. By default the decay is linear, but by setting this cvar to 1 the time will decay exponentially, moving slowly to begin with and then faster and faster as the timer reaches 0. This means that the grace period will remain long for longer which may make sense in conjuction with the setting above.
+
+To illustrate how the timer behaves with default settings:
+Ghost overtime kicks in at 15 seconds on the clock and will add a maximum of 45 seconds to the round. This gives us a total of 15 + 45 = 60 seconds for the timer of 15 seconds to decay. 60 / 15 = 4, meaning each second on the clock during ghost overtime will last for 4 real seconds.
+
+    * Ghost is picked up at 15 seconds and is held for 16 seconds. The timer shows 10 (15 - 16/4 = 11, rounded down to 10 for simplicity).
+    * The ghost is dropped, making the timer speed up.
+    * 8 seconds later the ghost is picked up again. Since grace reset is enabled, the timer jumps from 2 to 8 seconds (10 - 8/4 = 8).

--- a/scripting/nt_competitive.sp
+++ b/scripting/nt_competitive.sp
@@ -113,8 +113,10 @@ public OnPluginStart()
 	g_hCenteredDisplayTarget			= CreateConVar("sm_competitive_display_remaining_players_target",	"2", "Who to center display remaining players to. 1 = spectators only, 2 = spectators and dead players, 3 = everyone", _, true, 1.0, true, 3.0);
 	g_hCenteredDisplayDivider	= CreateConVar("sm_competitive_display_remaining_players_divider", "—", "What kind of divider to use between the scores (eg. 3 vs 2, 3 v 2, 3--2)");
 	g_hCompForceCamera				= CreateConVar("sm_competitive_force_camera",				"1",				"Should fade to black be forced on death when live. Can be useful to disable on pugs etc.", _, true, 0.0, true, 1.0);
-	g_hGhostOvertime				= CreateConVar("sm_competitive_ghost_overtime",				"15",					"Freeze the round timer at this many seconds while the ghost is held. 0 = disabled", _, true, 0.0, true, 30.0);
-	g_hGhostOvertimeDecay			= CreateConVar("sm_competitive_ghost_overtime_decay",		"60",					"Decay the overtime over this many seconds. I.e. if the overtime is 15 seconds and it decays over 60 seconds, one overtime second will be 4 real seconds.", _, true, 0.0, true, 120.0);
+	g_hGhostOvertimeDecay			= CreateConVar("sm_competitive_ghost_overtime",				"45",					"Add up to this many seconds to the round time while the ghost is held.", _, true, 0.0, true, 120.0);
+	g_hGhostOvertimeGrace			= CreateConVar("sm_competitive_ghost_overtime_grace",		"15",					"Freeze the round timer at this many seconds while the ghost is held. Will decay and end at 0 when the overtime runs out. 0 = disabled", _, true, 0.0, true, 30.0);
+	g_hGhostOvertimeDecayExp		= CreateConVar("sm_competitive_ghost_overtime_decay_exp",	"0",					"Whether ghost overtime decay should be exponential or linear. Exponential requires grace reset to be enabled. 0 = linear, 1 = exponential", _, true, 0.0, true, 1.0);
+	g_hGhostOvertimeGraceReset		= CreateConVar("sm_competitive_ghost_overtime_grace_reset", "1", 					"When the ghost is picked up, reset the timer to where it would be on the decay curve if the ghost was never dropped. This means the full overtime can be used even when juggling.", _, true, 0.0, true, 1.0);
 #if defined KV_DEBUG
 	g_hDebugKeyValues				= CreateConVar("sm_competitive_keyvalues_test",				"1",					"Store match data into KeyValues file. Debug cvar.", _, true, 0.0, true, 1.0);
 #endif
@@ -287,10 +289,19 @@ public OnGhostCapture(client)
 public OnGhostPickUp(client)
 {
 	int gameState = GameRules_GetProp("m_iGameState");
-	if (gameState == 2 && g_isLive && !g_isPaused && GetConVarInt(g_hGhostOvertime) > 0)
+	if (gameState == 2 && g_isLive && !g_isPaused && GetConVarInt(g_hGhostOvertimeDecay) > 0)
 	{
-		// Inverval of 0.9 to tick before the second flips over to prevent HUD flicker
-		g_hTimer_GhostOvertime = CreateTimer(0.9, CheckGhostOvertime, _, TIMER_REPEAT);
+		bool graceReset = GetConVarBool(g_hGhostOvertimeGraceReset);
+		if (!graceReset)
+		{
+			float timeLeft = GameRules_GetPropFloat("m_fRoundTimeLeft");
+			if (timeLeft < g_fGhostOvertime)
+			{
+				g_fGhostOvertime = g_fGhostOvertimeTick = timeLeft;
+			}
+		}
+		// Inverval of 0.5 to tick before the second flips over to prevent HUD flicker
+		g_hTimer_GhostOvertime = CreateTimer(0.5, CheckGhostOvertime, _, TIMER_REPEAT);
 		CheckGhostOvertime(g_hTimer_GhostOvertime);
 	}
 }
@@ -314,15 +325,31 @@ public Action:CheckGhostOvertime(Handle:timer)
 	}
 
 	float timeLeft = GameRules_GetPropFloat("m_fRoundTimeLeft");
-	if (timeLeft < g_fGhostOvertime)
+	float graceTime = GetConVarFloat(g_hGhostOvertimeGrace);
+	if (timeLeft < graceTime)
 	{
-		float decayTime = GetConVarFloat(g_hGhostOvertimeDecay);
-		float roundTime = GetConVarFloat(g_hRoundTime) * 60;
-		float overtime = GetGameTime() - (g_fRoundTime + roundTime);
-		if (decayTime > 0 && overtime > 0)
+		float decayTime = GetConVarFloat(g_hGhostOvertimeDecay) + graceTime;
+		bool graceReset = GetConVarBool(g_hGhostOvertimeGraceReset);
+		if (graceReset)
 		{
-			float ghostOvertime = GetConVarFloat(g_hGhostOvertime) + 1;
-			g_fGhostOvertime = ghostOvertime - Pow(ghostOvertime, overtime / decayTime);
+			float roundTime = GetConVarFloat(g_hRoundTime) * 60;
+			float overtime = GetGameTime() - (g_fRoundTime + roundTime - graceTime);
+			bool decayExp = GetConVarBool(g_hGhostOvertimeDecayExp);
+			if (decayExp)
+			{
+				graceTime = graceTime + 1;
+				g_fGhostOvertime = graceTime - Pow(graceTime, overtime / decayTime);
+			}
+			else
+			{
+				g_fGhostOvertime = graceTime - graceTime * overtime / decayTime;
+			}
+		}
+		else
+		{
+			float timePassed = g_fGhostOvertimeTick - timeLeft;
+			g_fGhostOvertime -= timePassed * graceTime / decayTime;
+			g_fGhostOvertimeTick = float(RoundToCeil(g_fGhostOvertime));
 		}
 		// Round up to nearest int to prevent HUD flicker
 		GameRules_SetPropFloat("m_fRoundTimeLeft", float(RoundToCeil(g_fGhostOvertime)));

--- a/scripting/nt_competitive.sp
+++ b/scripting/nt_competitive.sp
@@ -262,11 +262,6 @@ public OnClientDisconnect(client)
 	g_survivedLastRound[client] = false;
 	g_isSpawned[client] = false;
 	g_isRecording[client] = false;
-
-	if (client == g_ghostCarrier)
-	{
-		OnGhostDrop(client);
-	}
 }
 
 public OnGhostCapture(client)
@@ -291,7 +286,6 @@ public OnGhostCapture(client)
 
 public OnGhostPickUp(client)
 {
-	g_ghostCarrier = client;
 	int gameState = GameRules_GetProp("m_iGameState");
 	if (gameState == 2 && g_isLive && !g_isPaused && GetConVarInt(g_hGhostOvertime) > 0)
 	{
@@ -303,7 +297,6 @@ public OnGhostPickUp(client)
 
 public OnGhostDrop(client)
 {
-	g_ghostCarrier = 0;
 	if (g_hTimer_GhostOvertime != INVALID_HANDLE)
 	{
 		CloseHandle(g_hTimer_GhostOvertime);

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -94,8 +94,10 @@ new g_furthestPlayedRound;
 new g_penalizedTeam;
 new g_ghostCapturingTeam;
 new g_epoch;
+new g_ghostCarrier;
 
 new Float:g_fRoundTime;
+new Float:g_fGhostOvertime;
 
 new bool:g_isAlltalkByDefault;
 new bool:g_isExpectingOverride;
@@ -160,6 +162,7 @@ new Handle:g_hCenteredDisplayRemaining;
 new Handle:g_hCenteredDisplayTarget;
 new Handle:g_hCompForceCamera;
 new Handle:g_hGhostOvertime;
+new Handle:g_hGhostOvertimeDecay;
 new Handle:g_hCenteredDisplayDivider;
 
 #if defined KV_DEBUG

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -94,7 +94,6 @@ new g_furthestPlayedRound;
 new g_penalizedTeam;
 new g_ghostCapturingTeam;
 new g_epoch;
-new g_ghostCarrier;
 
 new Float:g_fRoundTime;
 new Float:g_fGhostOvertime;

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -159,6 +159,7 @@ new Handle:g_hSuddenDeath;
 new Handle:g_hCenteredDisplayRemaining;
 new Handle:g_hCenteredDisplayTarget;
 new Handle:g_hCompForceCamera;
+new Handle:g_hGhostOvertime;
 new Handle:g_hCenteredDisplayDivider;
 
 #if defined KV_DEBUG
@@ -170,6 +171,7 @@ new Handle:g_hTimer_GoLive						= INVALID_HANDLE;
 new Handle:g_hTimer_UnPause					= INVALID_HANDLE;
 new Handle:g_hTimer_UnPause_Countdown	= INVALID_HANDLE;
 new Handle:g_hTimer_UnPause_HalfLeft		= INVALID_HANDLE;
+new Handle:g_hTimer_GhostOvertime		= INVALID_HANDLE;
 
 #if defined KV_DEBUG
 KeyValues g_kv;

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -97,6 +97,7 @@ new g_epoch;
 
 new Float:g_fRoundTime;
 new Float:g_fGhostOvertime;
+new Float:g_fGhostOvertimeTick;
 
 new bool:g_isAlltalkByDefault;
 new bool:g_isExpectingOverride;
@@ -160,8 +161,10 @@ new Handle:g_hSuddenDeath;
 new Handle:g_hCenteredDisplayRemaining;
 new Handle:g_hCenteredDisplayTarget;
 new Handle:g_hCompForceCamera;
-new Handle:g_hGhostOvertime;
 new Handle:g_hGhostOvertimeDecay;
+new Handle:g_hGhostOvertimeGrace;
+new Handle:g_hGhostOvertimeDecayExp;
+new Handle:g_hGhostOvertimeGraceReset;
 new Handle:g_hCenteredDisplayDivider;
 
 #if defined KV_DEBUG

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -4,7 +4,7 @@
 #endif
 #define _base_included_
 
-#define PLUGIN_VERSION "0.3.9.21"
+#define PLUGIN_VERSION "0.4.0"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 255 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.

--- a/scripting/nt_competitive/nt_competitive_parser.inc
+++ b/scripting/nt_competitive/nt_competitive_parser.inc
@@ -35,12 +35,15 @@ public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroa
 {
 	new victim = GetClientOfUserId(GetEventInt(event, "userid"));
 
-	// Did the death happen after round time ran out?
-	new Float:roundTimeSecs = GetConVarFloat(g_hRoundTime) * 60;
-	new Float:currentTime = GetGameTime();
-
-	if (currentTime - g_fRoundTime < roundTimeSecs)
+	// Did the death happen before round time ran out?
+	new gameState = GameRules_GetProp("m_iGameState");
+	if (gameState == 2)
 		g_survivedLastRound[victim] = false;
+
+	// Was the victim carrying the ghost?
+	if (victim == g_ghostCarrier) {
+		OnGhostDrop(victim);
+	}
 
 	if ( GetConVarInt(g_hKillVersobity) == 0 ) // Do nothing
 		return Plugin_Continue;
@@ -152,6 +155,8 @@ public Action:Event_RoundStart(Handle:event, const String:name[], bool:dontBroad
 		return Plugin_Continue;
 
 	g_fRoundTime = GetGameTime();
+	g_fGhostOvertime = GetConVarFloat(g_hGhostOvertime) + 1;
+	g_ghostCarrier = 0;
 
 	// Game is currently being unpaused (points being recovered etc). Stop here.
 	if (g_isCurrentlyUnPausing)

--- a/scripting/nt_competitive/nt_competitive_parser.inc
+++ b/scripting/nt_competitive/nt_competitive_parser.inc
@@ -40,11 +40,6 @@ public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroa
 	if (gameState == 2)
 		g_survivedLastRound[victim] = false;
 
-	// Was the victim carrying the ghost?
-	if (victim == g_ghostCarrier) {
-		OnGhostDrop(victim);
-	}
-
 	if ( GetConVarInt(g_hKillVersobity) == 0 ) // Do nothing
 		return Plugin_Continue;
 
@@ -156,7 +151,6 @@ public Action:Event_RoundStart(Handle:event, const String:name[], bool:dontBroad
 
 	g_fRoundTime = GetGameTime();
 	g_fGhostOvertime = GetConVarFloat(g_hGhostOvertime) + 1;
-	g_ghostCarrier = 0;
 
 	// Game is currently being unpaused (points being recovered etc). Stop here.
 	if (g_isCurrentlyUnPausing)

--- a/scripting/nt_competitive/nt_competitive_parser.inc
+++ b/scripting/nt_competitive/nt_competitive_parser.inc
@@ -150,7 +150,7 @@ public Action:Event_RoundStart(Handle:event, const String:name[], bool:dontBroad
 		return Plugin_Continue;
 
 	g_fRoundTime = GetGameTime();
-	g_fGhostOvertime = GetConVarFloat(g_hGhostOvertime) + 1;
+	g_fGhostOvertime = g_fGhostOvertimeTick = GetConVarFloat(g_hGhostOvertimeGrace);
 
 	// Game is currently being unpaused (points being recovered etc). Stop here.
 	if (g_isCurrentlyUnPausing)

--- a/scripting/nt_competitive_overlay/nt_competitive_overlay_parser.inc
+++ b/scripting/nt_competitive_overlay/nt_competitive_overlay_parser.inc
@@ -7,14 +7,14 @@
 public Action:Event_RoundStart(Handle:event, const String:name[], bool:dontBroadcast)
 {
 	new winner = Competitive_GetWinner();
-	
+
 	if (winner == TEAM_JINRAI)
 		strcopy(g_winner, sizeof(g_winner), "Jinrai");
 	else if (winner == TEAM_NSF)
 		strcopy(g_winner, sizeof(g_winner), "NSF");
 	else
 		strcopy(g_winner, sizeof(g_winner), "");
-	
+
 	g_fGameTime_LastRound = GetGameTime();
 }
 
@@ -22,33 +22,33 @@ public Action:SayCallback_CasterMsg(client, const String:commandName[], arcg)
 {
 	if ( !Client_IsValid(client) || !g_IsSettingCasterMsg[client] || !Client_IsAdmin(client) )
 		return Plugin_Continue;
-	
+
 	new String:message[MAX_DATA_LENGTH];
 	GetCmdArgString(message, sizeof(message));
 	StripQuotes(message);
-	
+
 	strcopy(casterMessage, sizeof(casterMessage), message);
-	
+
 	PrintToChat(client, "Overlay message updated.");
-	
+
 	RemoveCommandListener(SayCallback_CasterMsg, "say");
 	RemoveCommandListener(SayCallback_CasterMsg, "say_team");
-	
+
 	g_IsSettingCasterMsg[client] = false;
-	
+
 	Command_CasterMenu(client, 1);
-	
+
 	return Plugin_Handled;
 }
 
 public Action:Timer_UpdateData(Handle:timer)
-{	
+{
 	if (!IsSQLInitialized)
 	{
 		PrintToServer("!IsSQLInitialized");
 		return Plugin_Continue;
 	}
-	
+
 	// Variables to store the data in
 	new String:teamName_Jinrai[MAX_DATA_LENGTH];
 	new String:teamName_NSF[MAX_DATA_LENGTH];
@@ -57,15 +57,15 @@ public Action:Timer_UpdateData(Handle:timer)
 	new bool:isLive;
 	new bool:isPaused;
 	new String:mapName[64];
-	
+
 	GetCurrentMap(mapName, sizeof(mapName));
-	
+
 	// Get data
 	isLive = Competitive_IsLive();
 	isPaused = Competitive_IsPaused();
 	teamScore_Jinrai = GetTeamScore(TEAM_JINRAI);
 	teamScore_NSF = GetTeamScore(TEAM_NSF);
-	
+
 	GetConVarString(hJinraiName, teamName_Jinrai, sizeof(teamName_Jinrai));
 	GetConVarString(hNSFName, teamName_NSF, sizeof(teamName_NSF));
 	// Use default team names if custom names aren't set
@@ -73,9 +73,9 @@ public Action:Timer_UpdateData(Handle:timer)
 		strcopy(teamName_Jinrai, sizeof(teamName_Jinrai), "Jinrai");
 	if (strlen(teamName_NSF) < 1)
 		strcopy(teamName_NSF, sizeof(teamName_NSF), "NSF");
-	
+
 	new String:sql[MAX_SQL_LENGTH];
-	
+
 	Format(sql, sizeof(sql), "UPDATE competitive_overlay SET \
 										Score_Jinrai=?, \
 										Score_NSF=?, \
@@ -91,16 +91,16 @@ public Action:Timer_UpdateData(Handle:timer)
 										Gametime_RoundLength=?, \
 										Gametime_FreezeLength=?, \
 										Winner=?");
-	
+
 	new String:sqlError[MAX_DATA_LENGTH];
 	new Handle:hSQL_Stmt = SQL_PrepareQuery(db, sql, sqlError, sizeof(sqlError));
-	
+
 	if (hSQL_Stmt == INVALID_HANDLE)
 	{
 		LogError("SQL error: %s", sqlError);
 		return Plugin_Continue;
 	}
-	
+
 	SQL_BindParamInt	(hSQL_Stmt,	0,	teamScore_Jinrai,	false	); // (int)		Score_Jinrai
 	SQL_BindParamInt	(hSQL_Stmt,	1,	teamScore_NSF,		false	); // (int)		Score_NSF
 	SQL_BindParamString	(hSQL_Stmt,	2,	teamName_Jinrai,	false	); // (str)		Teamname_Jinrai
@@ -115,14 +115,14 @@ public Action:Timer_UpdateData(Handle:timer)
 	SQL_BindParamFloat	(hSQL_Stmt, 11,	GetConVarFloat(hRoundTime)	); // (float)	Gametime_RoundLength
 	SQL_BindParamFloat	(hSQL_Stmt, 12,	GetConVarFloat(hFreezeTime)	); // (float)	Gametime_FreezeLength
 	SQL_BindParamString	(hSQL_Stmt, 13, g_winner,			false	); // (str)		Winner
-	
+
 	if (!SQL_Execute(hSQL_Stmt))
 	{
 		LogError("SQL error: %s", sqlError);
 		CloseHandle(hSQL_Stmt);
 		return Plugin_Continue;
 	}
-	
+
 	CloseHandle(hSQL_Stmt);
 	return Plugin_Continue;
 }


### PR DESCRIPTION
Implements ghost overtime which makes the timer slow down near end of round when the ghost is held. Note that this depends on [nt_ghostcap v1.9.0](https://github.com/softashell/nt-sourcemod-plugins/pull/13). 

Ghost overtime is also implemented as a [stand-alone plugin](https://github.com/Agiel/nt-ghost-overtime), but requires tight integration with the comp plugin due to interactions with pause etc. Both plugins **should not** be used at the same time.

The overtime is controlled by four new cvars
* *sm_competitive_ghost_overtime* (Default: 45)
    * Controls in seconds the maximum amount of overtime that can be added to the base clock.
* *sm_competitive_ghost_overtime_grace* (Default: 15)
    * Controls at how many seconds on the clock the overtime kicks in.
* *sm_competitive_ghost_overtime_grace_reset* (Default: 1)
    * Controls whether the grace time should be reset when picking up the ghost. The grace time *will never be reset fully*, but instead set to what the timer would have been at if the ghost had been held from when the timer showed *sm_competitive_ghost_overtime_grace*. I.e. a round can never be extended by more than what *sm_competitive_ghost_overtime* is set to.
* *sm_competitive_ghost_overtime_decay_exp* (Default: 0)
    * There are two modes for the timer decay. By default the decay is linear, but by setting this cvar to 1 the time will decay exponentially, moving slowly to begin with and then faster and faster as the timer reaches 0. This means that the grace period will remain long for longer which may make sense in conjuction with the setting above.

To illustrate how the timer behaves with default settings:  
Ghost overtime kicks in at 15 seconds on the clock and will add a maximum of 45 seconds to the round. This gives us a total of 15 + 45 = 60 seconds for the timer of 15 seconds to decay. 60 / 15 = 4, meaning each second on the clock during ghost overtime will last for 4 real seconds.

* Ghost is picked up at 15 seconds and is held for 16 seconds. The timer shows 10 (15 - 16/4 = 11, rounded down to 10 for simplicity).  
* The ghost is dropped, making the timer speed up.
* 8 seconds later the ghost is picked up again. Since grace reset is enabled, the timer jumps from 2 to 8 seconds (10 - 8/4 = 8).

*Note that the upcoming tournament (Winter Warzone 2023) will have grace reset disabled.*

This pull request also contains a change to use the *m_iGameState* prop instead of round time to determine whether the round has ended, with regards to player kills.