### PR TITLE
Print the actual time left to chat when overtime is activated

### DIFF
--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -98,6 +98,7 @@ new g_epoch;
 new Float:g_fRoundTime;
 new Float:g_fGhostOvertime;
 new Float:g_fGhostOvertimeTick;
+new bool:g_bGhostOvertimeFirstTick;
 
 new bool:g_isAlltalkByDefault;
 new bool:g_isExpectingOverride;


### PR DESCRIPTION
The actual time left in seconds will be printed when ghost overtime is first activated.
After that the time left will be printed every multiple of grace time (default 15 seconds).
Below grace time it'll be printed every 5 seconds, and finally, every second for the last 5.