### PR TITLE
Fix Menu handler compiler warning

### DIFF
--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -4,7 +4,7 @@
 #endif
 #define _base_included_
 
-#define PLUGIN_VERSION "0.4.2"
+#define PLUGIN_VERSION "0.4.3"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 255 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.

--- a/scripting/nt_competitive/nt_competitive_panel.inc
+++ b/scripting/nt_competitive/nt_competitive_panel.inc
@@ -417,7 +417,7 @@ Menu BuildClientMenu()
 public int Menu_Clients(Menu menu, MenuAction action, client, choice)
 {
 	if (action != MenuAction_Select)
-		return;
+		return 0;
 
 	decl String:targetString[32];
 	menu.GetItem( choice, targetString, sizeof(targetString) );
@@ -427,10 +427,11 @@ public int Menu_Clients(Menu menu, MenuAction action, client, choice)
 	if ( !IsValidClient(target) )
 	{
 		PrintToChat(client, "This player has left the server.");
-		return;
+		return 0;
 	}
 
 	RefereeMenu_ClientActions(client);
+	return 0;
 }
 
 #if defined KV_DEBUG


### PR DESCRIPTION
Fix MenuHandler warning:
> function has explicit 'int' tag but does not return a value