### PR TITLE
Add global fwd for player score change

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,30 @@ Ghost overtime kicks in at 15 seconds on the clock and will add a maximum of 45 
     * Ghost is picked up at 15 seconds and is held for 16 seconds. The timer shows 10 (15 - 16/4 = 11, rounded down to 10 for simplicity).
     * The ghost is dropped, making the timer speed up.
     * 8 seconds later the ghost is picked up again. Since grace reset is enabled, the timer jumps from 2 to 8 seconds (10 - 8/4 = 8).
+
+## Player score manipulation
+The nt_competitive plugin modifies player score/deaths values under some conditions. If you're a plugin developer and would like to override this behaviour, a global forward is exposed for this:
+```sp
+function Action Competitive_OnPlayerScoreChange(PlayerScoreChangeReason reason, int client);
+```
+Example of overriding the score change behaviour from your plugin:
+```sp
+#include <sourcemod>
+
+// needed for the PlayerScoreChangeReason enum definition
+#include "nt_competitive/nt_competitive_shared"
+
+
+public Action Competitive_OnPlayerScoreChange(XpChangeReason reason, int client)
+{
+    bool allow = true;
+
+    if ( /* my custom condition */ )
+    {
+        allow = false; // Block the nt_competitive score change!
+    }
+
+    return allow ? Plugin_Continue : Plugin_Handled;
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -188,7 +188,27 @@ Example of overriding the score change behaviour from your plugin:
 // needed for the PlayerScoreChangeReason enum definition
 #include "nt_competitive/nt_competitive_shared"
 
+// optional: handle cases where the forward doesn't exist,
+// if it's critical to your plugin
+public void OnAllPluginsLoaded()
+{
+    if (!LibraryExists("CompetitiveFwds"))
+    {
+        PrintToServer("Competitive forwards don't exist!");
 
+        if (null != FindConVar("sm_competitive_version"))
+        {
+            // nt_competitive exists, but it doesn't have the forward.
+            // Is the nt_competitive plugin out of date?
+        }
+        else
+        {
+            // nt_competitive plugin does not exist
+        }
+    }
+}
+
+// listener for the global forward from nt_competitive
 public Action Competitive_OnPlayerScoreChange(XpChangeReason reason, int client)
 {
     bool allow = true;

--- a/scripting/nt_competitive.sp
+++ b/scripting/nt_competitive.sp
@@ -14,6 +14,7 @@
 //#define FLATTEN_INCLUDE_PATHS
 
 #if defined(FLATTEN_INCLUDE_PATHS)
+#include "nt_competitive_shared"
 #include "nt_competitive_base"
 #include "nt_competitive_hooks"
 #include "nt_competitive_panel"
@@ -21,6 +22,7 @@
 #else
 // If you're compiling using Spider or other in-browser compiler,
 // and these include paths are failing, un-comment the FLATTEN_INCLUDE_PATHS compile flag above.
+#include "nt_competitive/nt_competitive_shared"
 #include "nt_competitive/nt_competitive_base"
 #include "nt_competitive/nt_competitive_hooks"
 #include "nt_competitive/nt_competitive_panel"
@@ -48,6 +50,9 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 public void OnPluginStart()
 {
+	g_hGFwd_OnPlayerScoreChange = CreateGlobalForward("Competitive_OnPlayerScoreChange",
+		ET_Hook, Param_Any, Param_Cell);
+
 	RegConsoleCmd("sm_ready",		Command_Ready,				"Mark yourself as ready for a competitive match.");
 
 	RegConsoleCmd("sm_unready",		Command_UnReady,			"Mark yourself as not ready for a competitive match.");
@@ -256,9 +261,15 @@ void PostAuthXpRecovery(int client)
 			}
 		}
 
+		if (!StartPlayerScoreChange(PLRSCORECHANGE_REASON_PLAYER_REJOIN, client))
+		{
+			continue;
+		}
+
 		// Set the actual XP & deaths
 		SetPlayerXP(client, xp);
 		SetPlayerDeaths(client, deaths);
+
 		break;
 	}
 

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -4,10 +4,11 @@
 #endif
 #define _NT_COMPETITIVE_BASE_INC_
 
+
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "2.0.1"
+#define PLUGIN_VERSION "2.1.0"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 128 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.
@@ -94,6 +95,8 @@ Handle g_hTimer_LiveCountdown = INVALID_HANDLE,
 	g_hTimer_UnPause_Countdown = INVALID_HANDLE,
 	g_hTimer_UnPause_HalfLeft = INVALID_HANDLE,
 	g_hTimer_GhostOvertime = INVALID_HANDLE;
+
+Handle g_hGFwd_OnPlayerScoreChange = INVALID_HANDLE;
 
 enum {
 	CVAR_NONE = 0,
@@ -964,6 +967,19 @@ int PrintToAdmins(bool toChat = true, bool toConsole = false,
 	return n;
 }
 
+bool StartPlayerScoreChange(PlayerScoreChangeReason reason, int client)
+{
+	Call_StartForward(g_hGFwd_OnPlayerScoreChange);
+	Call_PushCell(reason);
+	Call_PushCell(client);
+	Action res = Plugin_Continue;
+	if (Call_Finish(res) != SP_ERROR_NONE)
+	{
+		ThrowError("Global forward call failed: error code %d", res);
+	}
+	return (res == Plugin_Continue);
+}
+
 void RestoreRound(int roundNumber, bool isZanshiRestore)
 {
 	if (roundNumber > g_furthestPlayedRound || roundNumber <= 0)
@@ -989,7 +1005,14 @@ void RestoreRound(int roundNumber, bool isZanshiRestore)
 		for (int i = 1; i <= MaxClients; i++)
 		{
 			if ( !IsClientInGame(i) || IsFakeClient(i) )
+			{
 				continue;
+			}
+
+			if (!StartPlayerScoreChange(PLRSCORECHANGE_REASON_ROUND_RESTORE, i))
+			{
+				continue;
+			}
 
 			SetPlayerDeaths(i, g_playerDeaths[i][roundNumber]); // Restore deaths
 			SetPlayerXP(i, g_playerXP[i][roundNumber]); // Restore XP
@@ -1005,6 +1028,10 @@ void EmptyScore()
 	for (int i = 1; i <= MaxClients; i++)
 	{
 		if (!IsClientInGame(i))
+		{
+			continue;
+		}
+		if (!StartPlayerScoreChange(PLRSCORECHANGE_REASON_ROUND_RESTORE, i))
 		{
 			continue;
 		}

--- a/scripting/nt_competitive/nt_competitive_shared.inc
+++ b/scripting/nt_competitive/nt_competitive_shared.inc
@@ -1,0 +1,19 @@
+// Double-include prevention
+#if defined _NT_COMPETITIVE_SHARED_INC_
+    #endinput
+#endif
+#define _NT_COMPETITIVE_SHARED_INC_
+
+
+// Whenever nt_competitive changes player score, it will emit the global forward
+// "Competitive_OnPlayerScoreChange(PlayerScoreChangeReason reason, int client)".
+// If you want to override this forward, you can check this reason to make a
+// decision on what should happen.
+enum PlayerScoreChangeReason {
+	// As part of round restore, typically during unpause.
+	PLRSCORECHANGE_REASON_ROUND_RESTORE = 0,
+	// This player just rejoined the server.
+	PLRSCORECHANGE_REASON_PLAYER_REJOIN,
+
+	PLRSCORECHANGE_REASON_OTHER
+};


### PR DESCRIPTION
Add a global forward for nt_competitive player score manipulation
events.

This allows third party plugins to override this behaviour with the
prototype:

`function Action Competitive_OnPlayerScoreChange(PlayerScoreChangeReason reason, int client);`

`PlayerScoreChangeReason` is defined in "nt_competitive/nt_competitive_shared.inc".

To intercept the score change, override and return `Plugin_Handled`. To
allow the score change to occur, return `Plugin_Continue`.

Optionally, you may enquire for the existence of the forward(s) with `LibraryExists`.