### PR TITLE
Fix match not being recorded if previous match didn't end and map changed

### DIFF
--- a/scripting/nt_competitive.sp
+++ b/scripting/nt_competitive.sp
@@ -163,6 +163,14 @@ public void OnMapStart()
 	ResetGlobalVariables(); // Make sure all global variables are reset properly
 }
 
+public void OnMapEnd()
+{
+	if (g_isLive)
+	{
+		ToggleLive();
+	}
+}
+
 public void OnConfigsExecuted()
 {
 	g_isAlltalkByDefault = GetConVarBool(g_hAlltalk);

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -617,7 +617,7 @@ void InitDirectory(const char[] sDir)
 // todo: check for redundant code in this
 void ToggleSourceTV()
 {
-	if (g_isSourceTVRecording)
+	if (g_isSourceTVRecording && !g_isLive)
 	{
 		ServerCommand("tv_stoprecord");
 		g_isSourceTVRecording = false;

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "3.0.0"
+#define PLUGIN_VERSION "3.0.1"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 128 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "3.0.1"
+#define PLUGIN_VERSION "3.0.2"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 128 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.
@@ -617,7 +617,7 @@ void InitDirectory(const char[] sDir)
 // todo: check for redundant code in this
 void ToggleSourceTV()
 {
-	if (g_isSourceTVRecording && !g_isLive)
+	if (g_isSourceTVRecording)
 	{
 		ServerCommand("tv_stoprecord");
 		g_isSourceTVRecording = false;


### PR DESCRIPTION
Added check to prevent STV recording from stopping if match is still live.

Perhaps an alternative fix would be to set `g_isSourceTVRecording = false;` on map start.

Fixes #55 