### PR TITLE
Logging

### DIFF
--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -785,17 +785,7 @@ void LogCompetitive(const char[] message, any ...)
 	char formatMsg[256];
 	VFormat(formatMsg, sizeof(formatMsg), message, 2);
 
-	char loggingPath[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, loggingPath, sizeof(loggingPath), "logs/competitive");
-
-	char debugFile[] = "logfile.log";
-	Format(loggingPath, sizeof(loggingPath), "%s/%s", loggingPath, debugFile);
-
-	Handle hFile = OpenFile(loggingPath, "a");
-
-	WriteFileLine(hFile, formatMsg);
-
-	CloseHandle(hFile);
+	LogToGame(formatMsg);
 }
 
 #if SOURCEMOD_V_MAJOR <= 1 && SOURCEMOD_V_MINOR < 9

--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "3.0.2"
+#define PLUGIN_VERSION "4.0.0"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 128 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.

--- a/scripting/nt_competitive/nt_competitive_hooks.inc
+++ b/scripting/nt_competitive/nt_competitive_hooks.inc
@@ -215,14 +215,20 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 
 	if (g_roundNumber == 1)
 	{
+		char zone[10];
+		FormatTime(zone, sizeof(zone), "%z");
+		char time[64];
+		FormatTime(time, sizeof(time), "%F %R", GetTime());
+		
 		char tournamentName[128];
 		GetConVarString(g_hCompetitionName, tournamentName, sizeof(tournamentName));
-		LogCompetitive("%s\nCompetitive match started: %s vs %s",
+		LogCompetitive("\n%s\nCompetitive match started:\n%s vs %s\n%s (%s)",
 			tournamentName,
-			g_teamName[TEAM_JINRAI], g_teamName[TEAM_NSF]);
+			g_teamName[TEAM_JINRAI], g_teamName[TEAM_NSF],
+			time, zone);
 	}
 
-	LogCompetitive("***** Round %i *****", g_roundNumber);
+	//LogCompetitive("***** Round %i *****", g_roundNumber);
 	if (g_shouldPause)
 	{
 		g_shouldPause = false;


### PR DESCRIPTION
Changes to help stats log parsing  
Server logs will look something like this after the change:
```
L 04/27/2025 - 03:38:29: 
pugtokyo
Competitive match started:
Jinrai vs NSF
2025-04-27 03:38 (+0200)
L 04/27/2025 - 03:38:29: [COMP] Round 1/15
```
*for some reason the server logs are dumb and print the date in MM/DD/YYYY format.

When the game goes live it will be clearly marked with the name of the competition, teams, and date/time when it started in the server's timezone along with what timezone the server is in. The end of the competitive match will also be logged. This will make it easier for people parsing logs for stats. Round end logging will not be handled by this change, I feel it's better to use the `nt_wincond` plugin to handle that as it controls all the win conditions and ends the round.
