### PR TITLE
Update logging to add map name 

### DIFF
--- a/scripting/nt_competitive/nt_competitive_base.inc
+++ b/scripting/nt_competitive/nt_competitive_base.inc
@@ -8,7 +8,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "4.0.0"
+#define PLUGIN_VERSION "4.1.0"
 
 #define MAX_STEAMID_LENGTH 44
 #define MAX_ROUNDS_PLAYED 128 // This is just a random large number used for 1d int arrays because it's cheap and simple. A single comp game should never have more rounds than this to avoid weirdness.

--- a/scripting/nt_competitive/nt_competitive_hooks.inc
+++ b/scripting/nt_competitive/nt_competitive_hooks.inc
@@ -220,12 +220,16 @@ public Action Event_RoundStart(Event event, const char[] name, bool dontBroadcas
 		char time[64];
 		FormatTime(time, sizeof(time), "%F %R", GetTime());
 		
+		char mapName[32];
+		GetCurrentMap(mapName, sizeof(mapName));
+		
 		char tournamentName[128];
 		GetConVarString(g_hCompetitionName, tournamentName, sizeof(tournamentName));
-		LogCompetitive("\n%s\nCompetitive match started:\n%s vs %s\n%s (%s)",
+		
+		LogCompetitive("\n%s\nCompetitive match started:\n%s vs %s\n%s (%s)\n%s",
 			tournamentName,
 			g_teamName[TEAM_JINRAI], g_teamName[TEAM_NSF],
-			time, zone);
+			time, zone, mapName);
 	}
 
 	//LogCompetitive("***** Round %i *****", g_roundNumber);


### PR DESCRIPTION
Map name seemed to be missing completely from logs, so we can add it with all the other info we are logging when competition goes live like this:

```
L 07/02/2025 - 02:31:27: 
pugtokyo
Competitive match started:
Blood and Thunder vs NSF
2025-07-02 02:31 (+0200)
nt_rise_ctg
```